### PR TITLE
Update display of contents of Cargo.toml

### DIFF
--- a/src/doc/src/getting-started/first-steps.md
+++ b/src/doc/src/getting-started/first-steps.md
@@ -29,6 +29,9 @@ This is all we need to get started. First, let’s check out `Cargo.toml`:
 name = "hello_world"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
+edition = "2018"
+
+[dependencies]
 ```
 
 This is called a **manifest**, and it contains all of the metadata that Cargo


### PR DESCRIPTION
When creating a (binary) program using 'cargo new', with the new 2018 version of Rust the autogenerated Cargo.toml file contains a couple of additional lines. These lines have to do with edition and dependencies.